### PR TITLE
update sls doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ pip install -U aliyun-log-python-sdk
 ## Other resources
 
 1. Alicloud Log Service homepage：http://www.aliyun.com/product/sls/
-2. Alicloud Log Service doc：http://docs.aliyun.com/#/sls
+2. Alicloud Log Service doc：https://help.aliyun.com/product/28958.html
 3. for any issues, please submit support tickets

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,5 +44,5 @@ pip install -U aliyun-log-python-sdk
 ## 其他资源：
 
 1. 日志服务产品介绍：http://www.aliyun.com/product/sls/
-2. 日志服务产品文档：http://docs.aliyun.com/#/sls
+2. 日志服务产品文档：https://help.aliyun.com/product/28958.html
 3. 其他问题请提工单


### PR DESCRIPTION
Alicloud Log Service doc has changed to https://help.aliyun.com/product/28958.html. For a better usage reference, update the doc link.