### PR TITLE
support to compress data for get/put API with zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # User Guide (中文)
 
+[![Documentation Status](https://readthedocs.org/projects/aliyun-log-python-sdk/badge/?version=latest)](http://aliyun-log-python-sdk.readthedocs.io/?badge=latest)
 [![Pypi Version](https://badge.fury.io/py/aliyun-log-python-sdk.svg)](https://badge.fury.io/py/aliyun-log-python-sdk)
 [![Travis CI](https://travis-ci.org/aliyun/aliyun-log-python-sdk.svg?branch=master)](https://travis-ci.org/aliyun/aliyun-log-python-sdk)
 [![Development Status](https://img.shields.io/pypi/status/aliyun-log-python-sdk.svg)](https://pypi.python.org/pypi/aliyun-log-python-sdk/)

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,5 +1,6 @@
 # User Guide
 
+[![Documentation Status](https://readthedocs.org/projects/aliyun-log-python-sdk/badge/?version=latest)](http://aliyun-log-python-sdk.readthedocs.io/?badge=latest)
 [![Pypi Version](https://badge.fury.io/py/aliyun-log-python-sdk.svg)](https://badge.fury.io/py/aliyun-log-python-sdk)
 [![Travis CI](https://travis-ci.org/aliyun/aliyun-log-python-sdk.svg?branch=master)](https://travis-ci.org/aliyun/aliyun-log-python-sdk)
 [![Development Status](https://img.shields.io/pypi/status/aliyun-log-python-sdk.svg)](https://pypi.python.org/pypi/aliyun-log-python-sdk/)

--- a/aliyun/log/version.py
+++ b/aliyun/log/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.9'
+__version__ = '0.6.10'
 USER_AGENT = 'log-python-sdk-v-' + __version__
 API_VERSION = '0.6.0'
 


### PR DESCRIPTION
1. use zip when passing compress=True to putLogs
2. getLogs will ask zip format from server and parsing content dynamically basing on x-log-compressiontype header rather than API parameter.