### PR TITLE
add an error handling and don't copy machine group for `copy_project` by default

### DIFF
--- a/aliyun/log/index_config.py
+++ b/aliyun/log/index_config.py
@@ -99,9 +99,9 @@ class IndexLineConfig(object):
 
     def from_json(self, json_value):
         self.token_list = json_value["token"]
-        self.case_sensitive = bool(json_value["caseSensitive"])
-        self.include_keys = Util.get_json_value(json_value, "include_keys", None)
-        self.exclude_keys = Util.get_json_value(json_value, "exclude_keys", None)
+        self.case_sensitive = bool(json_value.get("caseSensitive", False))
+        self.include_keys = json_value.get("include_keys", None)
+        self.exclude_keys = json_value.get("exclude_keys", None)
 
 
 class IndexConfig(object):
@@ -158,4 +158,4 @@ class IndexConfig(object):
                 key_config.from_json(value)
                 self.key_config_list[key] = key_config
 
-        self.modify_time = Util.get_json_value(json_value, "lastModifyTime", int(time.time()))
+        self.modify_time = json_value.get("lastModifyTime", int(time.time()))

--- a/aliyun/log/logclient.py
+++ b/aliyun/log/logclient.py
@@ -1921,7 +1921,7 @@ class LogClient(object):
         (resp, header) = self._send('POST', project, body_str, resource, params, headers)
         return ConsumerGroupHeartBeatResponse(resp, header)
 
-    def copy_project(self, from_project, to_project, to_client=None):
+    def copy_project(self, from_project, to_project, to_client=None, copy_machine_group=False):
         """
         copy project, logstore, machine group and logtail config to target project,
         expecting the target project doens't exist
@@ -1935,11 +1935,14 @@ class LogClient(object):
         :type to_client: LogClient
         :param to_client: logclient instance
 
+        :type copy_machine_group: bool
+        :param copy_machine_group: if copy machine group resources, False by default.
+
         :return: None
         """
         if to_client is None:
             to_client = self
-        return copy_project(self, to_client, from_project, to_project)
+        return copy_project(self, to_client, from_project, to_project, copy_machine_group)
 
     def list_project(self, offset=0, size=100):
         """ list the project

--- a/aliyun/log/logclient_operator.py
+++ b/aliyun/log/logclient_operator.py
@@ -3,7 +3,7 @@ from functools import wraps
 import six
 
 
-def copy_project(from_client, to_client, from_project, to_project):
+def copy_project(from_client, to_client, from_project, to_project, copy_machine_group=False):
     """
     copy project, logstore, machine group and logtail config to target project,
     expecting the target project doens't exist
@@ -18,6 +18,11 @@ def copy_project(from_client, to_client, from_project, to_project):
 
     :type to_project: string
     :param to_project: project name
+
+    :type copy_machine_group: bool
+    :param copy_machine_group: if copy machine group resources, False by default.
+
+
     :return:
     """
 
@@ -67,7 +72,7 @@ def copy_project(from_client, to_client, from_project, to_project):
 
     # list machine group and copy them
     offset, size = 0, default_fetch_size
-    while True:
+    while copy_machine_group:
         ret = from_client.list_machine_group(from_project, offset=offset, size=size)
         count = ret.get_machine_group_count()
         total = ret.get_machine_group_total()

--- a/aliyun/log/logtail_config_detail.py
+++ b/aliyun/log/logtail_config_detail.py
@@ -228,7 +228,7 @@ class LogtailConfigHelper(object):
         logSample = json_value.get('logSample', '')
         config_name = json_value['configName']
         logstore_name = output_detail['logstoreName']
-        endpoint = Util.get_json_value(output_detail, 'endpoint')
+        endpoint = output_detail.get('endpoint', None)
 
         log_path = input_detail['logPath']
         file_pattern = input_detail['filePattern']
@@ -259,7 +259,7 @@ class LogtailConfigHelper(object):
         logSample = json_value.get('logSample', '')
 
         logstore_name = output_detail['logstoreName']
-        endpoint = Util.get_json_value(output_detail, 'endpoint')
+        endpoint = output_detail.get('endpoint')
         log_path = input_detail['logPath']
         file_pattern = input_detail['filePattern']
 

--- a/aliyun/log/machine_group_detail.py
+++ b/aliyun/log/machine_group_detail.py
@@ -48,13 +48,13 @@ class MachineGroupDetail(object):
         return json_value
 
     def from_json(self, json_value):
-        self.group_name = Util.get_json_value(json_value, "groupName")
-        self.group_type = Util.get_json_value(json_value, "groupType", "")
-        self.group_attribute = Util.get_json_value(json_value, "groupAttribute", {})
-        self.machine_type = Util.get_json_value(json_value, "machineIdentifyType")
-        self.machine_list = Util.get_json_value(json_value, "machineList")
-        self.create_time = Util.get_json_value(json_value, "crateTime")
-        self.last_modify_time = Util.get_json_value(json_value, "lastModifyTime")
+        self.group_name = json_value.get("groupName", None)
+        self.group_type = json_value.get("groupType", "")
+        self.group_attribute = json_value.get("groupAttribute", {})
+        self.machine_type = json_value.get("machineIdentifyType", None)
+        self.machine_list = json_value.get("machineList", None)
+        self.create_time = json_value.get("crateTime", None)
+        self.last_modify_time = json_value.get("lastModifyTime", None)
 
 
 class MachineStatus(object):

--- a/aliyun/log/util.py
+++ b/aliyun/log/util.py
@@ -147,12 +147,6 @@ class Util(object):
         return data
 
     @staticmethod
-    def get_json_value(json_map, key, default_value=None):
-        if key in json_map:
-            return json_map[key]
-        return default_value
-
-    @staticmethod
     def h_v_t(header, key):
         """
         get header value with title

--- a/tests/sample.py
+++ b/tests/sample.py
@@ -306,7 +306,7 @@ def main():
 
     # test copy project
     project_new = project + str(randint(1, 10000)) + "-copied"
-    client.copy_project(project, project_new)
+    client.copy_project(project, project_new, copy_machine_group=True)
 
     time.sleep(10)
     sample_cleanup(client, project, logstore, delete_project=True)


### PR DESCRIPTION
1. add an error handling in some json value.
2. don't copy machine group for `copy_project` by default by adding a parameter `copy_machine_group=False`