### PR TITLE
consumer worker: move network IO to run()

### DIFF
--- a/aliyun/log/consumer/worker.py
+++ b/aliyun/log/consumer/worker.py
@@ -40,8 +40,6 @@ class ConsumerWorker(Thread):
             logging.getLogger(__name__), {"consumer_worker": self})
         self.shard_consumers = {}
 
-        self.consumer_client.create_consumer_group(consumer_option.heartbeat_interval*2, consumer_option.in_order)
-        self.heart_beat = ConsumerHeatBeat(self.consumer_client, consumer_option.heartbeat_interval)
 
         if consumer_option.shared_executor is not None:
             self.own_executor = False
@@ -55,7 +53,12 @@ class ConsumerWorker(Thread):
         return self._executor
 
     def run(self):
-        self.logger.info('consumer worker "{0}" start '.format(self.option.consumer_name))
+        self.logger.info('consumer worker "%s" start',
+                         self.option.consumer_name)
+        self.consumer_client.create_consumer_group(
+            self.option.heartbeat_interval * 2, self.option.in_order)
+        self.heart_beat = ConsumerHeatBeat(self.consumer_client,
+                                           self.option.heartbeat_interval)
         self.heart_beat.start()
 
         while not self.shut_down_flag:


### PR DESCRIPTION
Make the heavy lifting work to running code, not in initialize code.