### PR TITLE
修复externalStoreConfig使用from_json处理后并没有保存结果值的bug

### DIFF
--- a/aliyun/log/external_store_config_response.py
+++ b/aliyun/log/external_store_config_response.py
@@ -53,8 +53,7 @@ class GetExternalStoreResponse(LogResponse):
 
     def __init__(self, resp, header):
         LogResponse.__init__(self, header, resp)
-        self.externalStoreConfig = ExternalStoreConfig("", "", "", "", "", "", "", "", "", "", "")
-        self.externalStoreConfig.from_json(resp)
+        self.externalStoreConfig = ExternalStoreConfig.from_json(resp)
 
     def get_external_store_config(self):
         """


### PR DESCRIPTION
在调用LogClient.get_external_store函数的时候发现返回值都为空，排查后发现GetExternalStoreResponse在调用from_json解析接口返回值的时候并没有保存结果，导致返回值为空。