### PR TITLE
Exclude incompatible protobuf version for python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements_py3 = [
     'elasticsearch',
     'jmespath',
     'dateparser',
-    'protobuf>=3.4.0',
+    'protobuf>=3.4.0,<4.0.0',
 ]
 requirements_py2 = [
     'six==1.14.0',


### PR DESCRIPTION
Hi,

A new version of the `protobuf` library was released yesterday (4.21.0). SInce then, new installations of `aliyun-log-python-sdk` don't work at all. It fails on import:
```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower)
```
I believe there should be an upper limit of the `protobuf` version in the library.

