### PR TITLE
Raise PutLogs raw body limit to 30 MB

### DIFF
--- a/aliyun/log/logclient.py
+++ b/aliyun/log/logclient.py
@@ -94,6 +94,7 @@ if six.PY3:
 CONNECTION_TIME_OUT = 120
 MAX_LIST_PAGING_SIZE = 500
 MAX_GET_LOG_PAGING_SIZE = 100
+MAX_PUT_LOG_SIZE = 30 * 1024 * 1024
 
 DEFAULT_QUERY_RETRY_COUNT = 5
 DEFAULT_QUERY_RETRY_INTERVAL = 0.5
@@ -429,7 +430,7 @@ class LogClient(object):
         return PutLogsResponse(header, resp)
 
     def put_logs(self, request):
-        """ Put logs to log service. up to 512000 logs up to 10MB size
+        """ Put logs to log service. up to 512000 logs up to 30MB size
         Unsuccessful operation will cause an LogException.
 
         :type request: PutLogsRequest
@@ -468,9 +469,9 @@ class LogClient(object):
                 pb_tag.Value = value
         body = logGroup.SerializeToString()
 
-        if len(body) > 10 * 1024 * 1024:  # 10 MB
+        if len(body) > MAX_PUT_LOG_SIZE:
             raise LogException('InvalidLogSize',
-                               "logItems' size exceeds maximum limitation: 10 MB. now: {0} MB.".format(
+                               "logItems' size exceeds maximum limitation: 30 MB. now: {0} MB.".format(
                                    len(body) / 1024.0 / 1024))
 
         headers = {'x-log-bodyrawsize': str(len(body)), 'Content-Type': 'application/x-protobuf'}

--- a/aliyun/log/version.py
+++ b/aliyun/log/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.47'
+__version__ = '0.9.48'
 
 import sys
 OS_VERSION = str(sys.platform)

--- a/tests/unit/test_logclient_mock.py
+++ b/tests/unit/test_logclient_mock.py
@@ -26,6 +26,50 @@ from aliyun.log import (
 from tests._helpers.fakes import error_response, make_client, mock_sls_response
 
 
+class _SizedBody(object):
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+
+class _SizedLogGroup(object):
+    def __init__(self, size):
+        self.size = size
+
+    def SerializeToString(self):
+        return _SizedBody(self.size)
+
+
+def _put_empty_log_group(monkeypatch, size):
+    import aliyun.log.logclient as logclient_module
+
+    monkeypatch.setattr(logclient_module, "LogGroup", lambda: _SizedLogGroup(size))
+    client = make_client(endpoint="cn-mock.example.com", project="mock-proj")
+    monkeypatch.setattr(
+        client,
+        "_send",
+        lambda *args, **kwargs: (b"", {"x-log-requestid": "mock-request-id"}),
+    )
+    request = PutLogsRequest(
+        "mock-proj", "store-1", "topic", "src", [], compress=False
+    )
+    return client.put_logs(request)
+
+
+def test_put_logs_accepts_30_mb_raw_body(monkeypatch):
+    _put_empty_log_group(monkeypatch, 30 * 1024 * 1024)
+
+
+def test_put_logs_rejects_raw_body_larger_than_30_mb(monkeypatch):
+    with pytest.raises(LogException) as excinfo:
+        _put_empty_log_group(monkeypatch, 30 * 1024 * 1024 + 1)
+
+    assert excinfo.value.get_error_code() == "InvalidLogSize"
+    assert "30 MB" in excinfo.value.get_error_message()
+
+
 @responses.activate
 def test_get_logs_returns_parsed():
     """GET /logs response is parsed into a GetLogsResponse with logs."""


### PR DESCRIPTION
## Summary

- raise the single PutLogs raw protobuf body limit from 10 MB to 30 MB
- update the validation message and API documentation
- bump the SDK patch version from 0.9.47 to 0.9.48
- add boundary tests for 30 MB and 30 MB + 1 byte

## Tests

- `python -m pytest tests/unit -q` (38 passed, 8 skipped)
- `python setup.py --version` (0.9.48)