### PR TITLE
fix: use labels type for legacy MetricStore creation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.9.51 (2026-09-07)
+
+**Breaking Changes**
+
+- create_metric_store now creates MetricStore V2 by using the labels type for __labels__ in the default prom substore.
+
 ## 0.9.43 (2026-02-04)
 
 **Breaking Changes**

--- a/aliyun/log/logclient.py
+++ b/aliyun/log/logclient.py
@@ -4917,7 +4917,7 @@ class LogClient(object):
         time.sleep(1)
         keys = [
             {'name': '__name__', 'type': 'text'},
-            {'name': '__labels__', 'type': 'text'},
+            {'name': '__labels__', 'type': 'labels'},
             {'name': '__time_nano__', 'type': 'long'},
             {'name': '__value__', 'type': 'double'},
         ]

--- a/aliyun/log/version.py
+++ b/aliyun/log/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.50'
+__version__ = '0.9.51'
 
 import sys
 OS_VERSION = str(sys.platform)

--- a/tests/ci/build-test/test_metric_store.py
+++ b/tests/ci/build-test/test_metric_store.py
@@ -1,0 +1,35 @@
+import json
+
+from aliyun.log import LogClient
+
+
+def test_create_metric_store_uses_labels(monkeypatch):
+    client = LogClient('cn-mock.example.com', 'mock-id', 'mock-key')
+    requests = []
+
+    def send(method, project, body, resource, params, headers):
+        requests.append((method, project, resource, json.loads(body.decode('utf-8'))))
+        return {}, {}
+
+    monkeypatch.setattr(client, '_send', send)
+    monkeypatch.setattr('aliyun.log.logclient.time.sleep', lambda seconds: None)
+    response = client.create_metric_store('my-project', 'my-metrics', ttl=18)
+
+    assert [(method, project, resource) for method, project, resource, body in requests] == [
+        ('POST', 'my-project', '/logstores'),
+        ('POST', 'my-project', '/logstores/my-metrics/substores'),
+    ]
+    assert requests[0][3]['telemetryType'] == 'Metrics'
+    assert requests[0][3]['logstoreName'] == 'my-metrics'
+    assert requests[0][3]['ttl'] == 18
+    assert requests[1][3] == {
+        'name': 'prom', 'ttl': 18, 'sortedKeyCount': 2, 'timeIndex': 2,
+        'keys': [
+            {'name': '__name__', 'type': 'text'},
+            {'name': '__labels__', 'type': 'labels'},
+            {'name': '__time_nano__', 'type': 'long'},
+            {'name': '__value__', 'type': 'double'},
+        ],
+    }
+    assert response.get_logstore_response() is not None
+    assert response.get_substore_response() is not None


### PR DESCRIPTION
`create_metric_store` still creates a logstore followed by a `prom` substore. Its default `__labels__` key now uses `labels` instead of `text`, selecting MetricStore V2.

Adds an offline regression test that captures both requests and verifies their order, Metrics telemetry type, and complete default substore schema. Bumps the package version from 0.9.50 to 0.9.51 and updates HISTORY.md.

Validation: package installation and `python3 -m pytest tests/ci/build-test/ -q` in the SDK build Docker image: 4 passed. Self review confirmed scope, compatibility, preserved source line endings, and no sensitive or local artifacts in the commit. Live SLS integration tests were not run.
